### PR TITLE
fix: remove the `-jammy` suffix from image tag

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ mongodb_uid: ''
 mongodb_gid: ''
 
 mongodb_container_image: "{{ mongodb_container_image_registry_prefix }}mongo:{{ mongodb_container_image_tag }}"
-mongodb_container_image_tag: "{{ mongodb_version }}-jammy"
+mongodb_container_image_tag: "{{ mongodb_version }}"
 mongodb_container_image_registry_prefix: "{{ mongodb_container_image_registry_prefix_upstream }}"
 mongodb_container_image_registry_prefix_upstream: "{{ mongodb_container_image_registry_prefix_upstream_default }}"
 mongodb_container_image_registry_prefix_upstream_default: docker.io/


### PR DESCRIPTION
Since mongodb 8 there is no jammy version of the container any more, they are now using noble as it is the newest ubuntu LTS.
To fix this issue with prevented the pull of the new version for now an the future I removed the `-jammy` ending  from the image-tag.

In my test it works perfectly fine. Please check if there was any important reason to use the explicit -jammy version in the beginning.